### PR TITLE
Change lwt_react name for Lwt 3.0

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -67,8 +67,8 @@ Library obus
     OBus_util,
     OBus_xml_parser,
     OBus_config
-  BuildDepends: lwt.unix, lwt.react, lwt.syntax, lwt.syntax.log, type_conv, xmlm
-  XMETARequires: lwt.unix, lwt.react, xmlm
+  BuildDepends: lwt.unix, lwt_react, lwt.syntax, lwt.syntax.log, type_conv, xmlm
+  XMETARequires: lwt.unix, lwt_react, xmlm
   XMETADescription: Pure OCaml implementation of D-Bus
 
 # +-------------------------------------------------------------------+
@@ -190,7 +190,7 @@ Executable "obus-gen-interface"
   Install: true
   CompiledObject: best
   MainIs: obus_gen_interface.ml
-  BuildDepends: lwt.unix, lwt.react, lwt.syntax, lwt.syntax.log, type_conv, xmlm, camlp4.quotations.o, camlp4.extend, camlp4.lib
+  BuildDepends: lwt.unix, lwt_react, lwt.syntax, lwt.syntax.log, type_conv, xmlm, camlp4.quotations.o, camlp4.extend, camlp4.lib
 
 Executable "obus-dump"
   Path: tools


### PR DESCRIPTION
`lwt.react` changed to `lwt_react` in Lwt >= 3.0, so the obus package on opam is still stuck on Lwt < 3.0.

Fixes https://github.com/ocaml/opam-repository/pull/8956