### PR TITLE
Add support for OCaml 4.06 and Lwt 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: c
+sudo: required
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
+sudo: required
+env:
+  matrix:
+    - OCAML_VERSION=4.02
+    - OCAML_VERSION=4.06
+os:
+  - linux

--- a/_oasis
+++ b/_oasis
@@ -67,8 +67,8 @@ Library obus
     OBus_util,
     OBus_xml_parser,
     OBus_config
-  BuildDepends: lwt.unix, lwt.react, lwt.syntax, lwt.syntax.log, type_conv, xmlm
-  XMETARequires: lwt.unix, lwt.react, xmlm
+  BuildDepends: lwt.unix, lwt_react, lwt.syntax, lwt.syntax.log, type_conv, xmlm
+  XMETARequires: lwt.unix, lwt_react, xmlm
   XMETADescription: Pure OCaml implementation of D-Bus
 
 # +-------------------------------------------------------------------+
@@ -190,7 +190,7 @@ Executable "obus-gen-interface"
   Install: true
   CompiledObject: best
   MainIs: obus_gen_interface.ml
-  BuildDepends: lwt.unix, lwt.react, lwt.syntax, lwt.syntax.log, type_conv, xmlm, camlp4.quotations.o, camlp4.extend, camlp4.lib
+  BuildDepends: lwt.unix, lwt_react, lwt.syntax, lwt.syntax.log, type_conv, xmlm, camlp4.quotations.o, camlp4.extend, camlp4.lib
 
 Executable "obus-dump"
   Path: tools

--- a/opam
+++ b/opam
@@ -20,3 +20,4 @@ depends: [
 ]
 dev-repo: "git://github.com/diml/obus"
 install: ["ocaml" "setup.ml" "-install"]
+available: [ ocaml-version >= "4.02.3" ]

--- a/opam
+++ b/opam
@@ -9,7 +9,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "obus"]]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "lwt" {>= "2.7.0"}
   "lwt_react"
   "react" {>= "1.0.0"}

--- a/opam
+++ b/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/diml/obus"
+bug-reports: "https://github.com/diml/obus/issues"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+remove: [["ocamlfind" "remove" "obus"]]
+depends: [
+  "ocamlfind"
+  "lwt" {< "3.0.0"}
+  "react" {>= "1.0.0"}
+  "type_conv"
+  "xmlm"
+  "ocamlbuild" {build}
+  "oasis" {build}
+]
+dev-repo: "git://github.com/diml/obus"
+install: ["ocaml" "setup.ml" "-install"]

--- a/opam
+++ b/opam
@@ -10,7 +10,8 @@ build: [
 remove: [["ocamlfind" "remove" "obus"]]
 depends: [
   "ocamlfind"
-  "lwt" {< "3.0.0"}
+  "lwt" {>= "2.7.0"}
+  "lwt_react"
   "react" {>= "1.0.0"}
   "type_conv"
   "xmlm"

--- a/src/oBus_auth.ml
+++ b/src/oBus_auth.ml
@@ -251,7 +251,7 @@ let stream_of_channels (ic, oc) =
 let stream_of_fd fd =
   make_stream
     ~recv:(fun () ->
-             let buf = Buffer.create 42 and tmp = String.create 1 in
+             let buf = Buffer.create 42 and tmp = Bytes.create 1 in
              let rec loop last =
                if Buffer.length buf > max_line_length then
                  raise_lwt (Auth_failure "input: line too long")
@@ -260,7 +260,7 @@ let stream_of_fd fd =
                    | 0 ->
                        raise_lwt (Auth_failure "input: premature end of input")
                    | 1 ->
-                       let ch = tmp.[0] in
+                       let ch = Bytes.get tmp 0 in
                        Buffer.add_char buf ch;
                        if last = '\r' && ch = '\n' then
                          return (Buffer.contents buf)
@@ -275,7 +275,7 @@ let stream_of_fd fd =
                if len = 0 then
                  return ()
                else
-                 Lwt_unix.write fd line ofs len >>= function
+                 Lwt_unix.write_string fd line ofs len >>= function
                    | 0 ->
                        raise_lwt (Auth_failure "output: zero byte written")
                    | n ->

--- a/src/oBus_path.ml
+++ b/src/oBus_path.ml
@@ -76,20 +76,20 @@ let empty = []
 let to_string = function
   | [] -> "/"
   | path ->
-      let str = create (List.fold_left (fun len elt -> len + length elt + 1) 0 path) in
+      let str = Bytes.create (List.fold_left (fun len elt -> len + length elt + 1) 0 path) in
       ignore
         (List.fold_left
            (fun pos elt ->
               match validate_element elt with
                 | None ->
-                    unsafe_set str pos '/';
+                    Bytes.unsafe_set str pos '/';
                     let len = length elt in
                     unsafe_blit elt 0 str (pos + 1) len;
                     pos + 1 + len
                 | Some error ->
                     raise (Invalid_string error))
            0 path);
-      str
+      Bytes.unsafe_to_string str
 
 let of_string str =
   match validate str with
@@ -102,31 +102,32 @@ let of_string str =
           else
             let i = rindex_from str j '/' in
             let len = j - i in
-            let elt = create len in
+            let elt = Bytes.create len in
             unsafe_blit str (i + 1) elt 0 len;
+            let elt = Bytes.unsafe_to_string elt in
             aux (elt :: acc) (i - 1)
         in
         aux [] (length str - 1)
 
 let escape s =
   let len = length s in
-  let r = create (len * 2) in
+  let r = Bytes.create (len * 2) in
   for i = 0 to len - 1 do
     let j = i * 2 and n = int_of_char s.[i] in
-    r.[j] <- char_of_int (n land 15 + int_of_char 'a');
-    r.[j + 1] <- char_of_int (n lsr 4 + int_of_char 'a')
+    Bytes.set r j (char_of_int (n land 15 + int_of_char 'a'));
+    Bytes.set r (j + 1) (char_of_int (n lsr 4 + int_of_char 'a'))
   done;
-  r
+  Bytes.unsafe_to_string r
 
 let unescape s =
   let len = length s / 2 in
-  let r = create len in
+  let r = Bytes.create len in
   for i = 0 to len - 1 do
     let j = i * 2 in
-    r.[i] <- char_of_int ((int_of_char s.[j] - int_of_char 'a') lor
-                            ((int_of_char s.[j + 1] - int_of_char 'a') lsl 4))
+    Bytes.set r i (char_of_int ((int_of_char s.[j] - int_of_char 'a') lor
+                                ((int_of_char s.[j + 1] - int_of_char 'a') lsl 4)))
   done;
-  r
+  Bytes.unsafe_to_string r
 
 let rec after prefix path = match prefix, path with
   | [], p -> Some p

--- a/src/oBus_transport.ml
+++ b/src/oBus_transport.ml
@@ -96,7 +96,7 @@ let make_socket domain typ addr =
     raise_lwt exn
 
 let rec write_nonce fd nonce pos len =
-  Lwt_unix.write fd nonce 0 16 >>= function
+  Lwt_unix.write_string fd nonce 0 16 >>= function
     | 0 ->
         raise_lwt (Failure "OBus_transport.connect: failed to send the nonce to the server")
     | n ->
@@ -272,7 +272,7 @@ let of_addresses ?switch ?(capabilities=OBus_auth.capabilities) ?mechanisms addr
         in
         (* Do authentication only once: *)
         try_lwt
-          Lwt_unix.write fd "\x00" 0 1 >>= function
+          Lwt_unix.write_string fd "\x00" 0 1 >>= function
             | 0 ->
                 raise_lwt (OBus_auth.Auth_failure "failed to send the initial null byte")
             | 1 ->

--- a/src/oBus_util.mli
+++ b/src/oBus_util.mli
@@ -54,7 +54,7 @@ val homedir : string Lwt.t Lazy.t
 (** All the following functions try to generate random numbers using
     /dev/urandom and can fallback to pseudo-random generator *)
 
-val fill_random : string -> int -> int -> unit
+val fill_random : bytes -> int -> int -> unit
   (** [fill_random str ofs len] Fill the given string from [ofs] to
       [ofs+len-1] with random bytes.  *)
 

--- a/src/oBus_uuid.ml
+++ b/src/oBus_uuid.ml
@@ -18,11 +18,11 @@ let of_string str =
 let to_string = OBus_util.hex_encode
 
 let generate () =
-  let uuid = String.create 16 in
+  let uuid = Bytes.create 16 in
   OBus_util.fill_random uuid 0 12;
   let v = Int32.of_float (Unix.time ()) in
-  uuid.[12] <- (Char.unsafe_chr (Int32.to_int (Int32.shift_right v 24)));
-  uuid.[13] <- (Char.unsafe_chr (Int32.to_int (Int32.shift_right v 16)));
-  uuid.[14] <- (Char.unsafe_chr (Int32.to_int (Int32.shift_right v 8)));
-  uuid.[15] <- (Char.unsafe_chr (Int32.to_int v));
-  uuid
+  Bytes.set uuid 12 (Char.unsafe_chr (Int32.to_int (Int32.shift_right v 24)));
+  Bytes.set uuid 13 (Char.unsafe_chr (Int32.to_int (Int32.shift_right v 16)));
+  Bytes.set uuid 14 (Char.unsafe_chr (Int32.to_int (Int32.shift_right v 8)));
+  Bytes.set uuid 15 (Char.unsafe_chr (Int32.to_int v));
+  Bytes.unsafe_to_string uuid

--- a/src/oBus_value.ml
+++ b/src/oBus_value.ml
@@ -296,10 +296,10 @@ let signature_of_string str =
 
 let string_of_signature signature =
   let len = signature_length signature in
-  let str = String.create len and i = ref 0 in
+  let str = Bytes.create len and i = ref 0 in
   let put_char ch =
     let j = !i in
-    String.unsafe_set str j ch;
+    Bytes.unsafe_set str j ch;
     i := j + 1
   in
   let write_basic t =
@@ -338,6 +338,7 @@ let string_of_signature signature =
         put_char 'v'
   in
   List.iter write_single signature;
+  let str = Bytes.unsafe_to_string str in
   try
     let _ = length_validate_signature in
     str
@@ -440,14 +441,14 @@ struct
 
   let array t l =
     if t = T.Basic T.Byte then begin
-      let s = String.create (List.length l) and i = ref 0 in
+      let s = Bytes.create (List.length l) and i = ref 0 in
       List.iter (function
                    | Basic(Byte x) ->
-                       String.unsafe_set s !i x;
+                       Bytes.unsafe_set s !i x;
                        incr i
                    | _ ->
                        invalid_arg "OBus_value.array: unexpected type") l;
-      Byte_array s
+      Byte_array (Bytes.unsafe_to_string s)
     end else begin
       List.iter (fun x ->
                    if type_of_single x <> t then

--- a/src/oBus_wire.ml
+++ b/src/oBus_wire.ml
@@ -283,18 +283,18 @@ end
    | Unsafe writing of integers                                      |
    +-----------------------------------------------------------------+ *)
 
-let put_char = String.unsafe_set
+let put_char = Bytes.unsafe_set
 let put_uint8 buf ofs x = put_char buf ofs (Char.unsafe_chr x)
 
 module type Integer_writers = sig
-  val put_int16 : string -> int -> int -> unit
-  val put_int32 : string -> int -> int32 -> unit
-  val put_int64 : string -> int -> int64 -> unit
-  val put_uint16 : string -> int -> int -> unit
-  val put_uint32 : string -> int -> int32 -> unit
-  val put_uint64 : string -> int -> int64 -> unit
+  val put_int16 : bytes -> int -> int -> unit
+  val put_int32 : bytes -> int -> int32 -> unit
+  val put_int64 : bytes -> int -> int64 -> unit
+  val put_uint16 : bytes -> int -> int -> unit
+  val put_uint32 : bytes -> int -> int32 -> unit
+  val put_uint64 : bytes -> int -> int64 -> unit
 
-  val put_uint : string -> int -> int -> unit
+  val put_uint : bytes -> int -> int -> unit
 end
 
 module LE_integer_writers : Integer_writers =
@@ -515,7 +515,7 @@ module FD_map = Map.Make(struct type t = Unix.file_descr let compare = Pervasive
 
 (* A pointer for serializing data *)
 type wpointer = {
-  buf : string;
+  buf : bytes;
   mutable ofs : int;
   max : int;
   fds : int FD_map.t;
@@ -713,7 +713,7 @@ struct
     let { Count.ofs = size; Count.fds = fds } = Count.message msg in
     if size > max_message_size then raise (Data_error(message_too_big size));
 
-    let buffer = String.create size in
+    let buffer = Bytes.create size in
     let ptr = {
       buf = buffer;
       ofs = 16;
@@ -821,7 +821,7 @@ struct
     let fds = Array.create fd_count Unix.stdin in
     FD_map.iter (fun fd index -> Array.unsafe_set fds index fd) ptr.fds;
 
-    (ptr.buf, fds)
+    (Bytes.unsafe_to_string ptr.buf, fds)
 end
 
 module LE_writer = Make_writer(LE_integer_writers)
@@ -870,7 +870,7 @@ let write_message_with_fds writer ?byte_order msg =
           lwt n = Lwt_unix.send_msg writer.w_file_descr [Lwt_unix.io_vector buf 0 len] (Array.to_list fds) in
           assert (n >= 0 && n <= len);
           (* Write what is remaining: *)
-          Lwt_io.write_from_exactly oc buf n (len - n)
+          Lwt_io.write_from_string_exactly oc buf n (len - n)
         end writer.w_channel
 
 (* +-----------------------------------------------------------------+
@@ -943,10 +943,10 @@ let read8 reader ptr =
 
 let read_bytes ptr len =
   if len < 0 || ptr.ofs + len > ptr.max then out_of_bounds ();
-  let s = String.create len in
+  let s = Bytes.create len in
   String.unsafe_blit ptr.buf ptr.ofs s 0 len;
   ptr.ofs <- ptr.ofs + len;
-  s
+  Bytes.unsafe_to_string s
 
 (* +-----------------------------------------------------------------+
    | Message reading                                                 |
@@ -1194,8 +1194,9 @@ module BE_reader = Make_reader(BE_integer_readers)
 let read_message ic =
   try_lwt
     Lwt_io.atomic begin fun ic ->
-      let buffer = String.create 16 in
+      let buffer = Bytes.create 16 in
       lwt () = Lwt_io.read_into_exactly ic buffer 0 16 in
+      let buffer = Bytes.unsafe_to_string buffer in
       (match get_char buffer 0 with
          | 'l' -> LE_reader.read_message
          | 'B' -> BE_reader.read_message
@@ -1203,8 +1204,9 @@ let read_message ic =
         buffer
         (fun length f ->
            let length = length - 16 in
-           let buffer = String.create length in
+           let buffer = Bytes.create length in
            lwt () = Lwt_io.read_into_exactly ic buffer 0 length in
+           let buffer = Bytes.unsafe_to_string buffer in
            f { buf = buffer; ofs = 0; max = length; fds = [||] } None return)
     end ic
   with exn ->
@@ -1261,8 +1263,9 @@ let read_message_with_fds reader  =
   let consumed_fds = ref [] in
   try_lwt
     Lwt_io.atomic begin fun ic ->
-      let buffer = String.create 16 in
+      let buffer = Bytes.create 16 in
       lwt () = Lwt_io.read_into_exactly ic buffer 0 16 in
+      let buffer = Bytes.unsafe_to_string buffer in
       (match get_char buffer 0 with
          | 'l' -> LE_reader.read_message
          | 'B' -> BE_reader.read_message
@@ -1272,6 +1275,7 @@ let read_message_with_fds reader  =
            let length = length - 16 in
            let buffer = String.create length in
            lwt () = Lwt_io.read_into_exactly ic buffer 0 length in
+           let buffer = Bytes.unsafe_to_string buffer in
            f { buf = buffer; ofs = 0; max = length; fds = [||] } (Some(consumed_fds, reader.r_pending_fds)) return)
     end reader.r_channel
   with exn ->

--- a/tests/gen_random.ml
+++ b/tests/gen_random.ml
@@ -21,11 +21,11 @@ let option f =
 (* Generate a random non-empty string *)
 let string max_len =
   let len = 1 + Random.int max_len in
-  let str = String.create len in
+  let str = Bytes.create len in
   for i = 0 to len - 1 do
-    str.[i] <- char_of_int (Char.code 'a' + Random.int 26)
+    Bytes.set str i (char_of_int (Char.code 'a' + Random.int 26))
   done;
-  str
+  Bytes.unsafe_to_string str
 
 (* Generate an object path *)
 let path () =

--- a/tools/utils.ml
+++ b/tools/utils.ml
@@ -42,14 +42,14 @@ let parse_file fname =
     parse_xml fname
 
 let file_name_of_interface_name name =
-  let result = String.create (String.length name) in
+  let result = Bytes.create (String.length name) in
   for i = 0 to String.length name - 1 do
     if name.[i] = '.' then
-      result.[i] <- '_'
+      Bytes.set result i '_'
     else
-      result.[i] <- name.[i]
+      Bytes.set result i name.[i]
   done;
-  result
+  Bytes.unsafe_to_string result
 
 let paren top s = if top then s else sprintf "(%s)" s
 


### PR DESCRIPTION
- Adds an `opam` file.
- Uses `lwt_react` instead of `lwt.react`, to support Lwt 3.
- Uses `Bytes` for safe-string support.
- Adds Travis tests.

Note that the Travis tests do not actually run the tests, which fail for me with:

```
=[ garbage collection ]=========================================================
safety check: success
testing garbage collection of a signal without a switch: failure
testing garbage collection of a signal with a switch: success

Test failed.

1 of 5 tests failed.
```

Also, the tests sometimes hang at:

```
=[ communication ]==============================================================
sending and receiving 100 messages through the message bus.
```

I don't think I changed anything related to this. I tested the original sources using 4.02.3 and they always hang for me too. I tried removing the communication test to try the GC tests, but that then failed with:

```
=[ garbage collection ]=========================================================
main.native: obus(transport): autolaunch failed: End_of_file
main.native: obus(bus): Failed to open a connection to the session bus: End_of_file
test failed with: End_of_file
```

So maybe the unit-tests just don't work?