### PR TITLE
Tweak opam file and update CHANGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+1.1.8 (unreleased)
+------------------
+
+* opam: add dependency on `oasis`, `lwt_react`, `lwt_camlp4`, `lwt_log`
+* opam: `ocamlfind` is now a build dependency
+* add support for OCaml 4.06 and `lwt` 3
+* bump minimum OCaml version to 4.02.3
+* enable travis tests
+* fix missing signature validation
+
 1.1.7 (2016-07-18)
 ------------------
 

--- a/opam
+++ b/opam
@@ -12,6 +12,8 @@ depends: [
   "ocamlfind" {build}
   "lwt" {>= "2.7.0"}
   "lwt_react"
+  "lwt_camlp4"
+  "lwt_log"
   "react" {>= "1.0.0"}
   "type_conv"
   "xmlm"


### PR DESCRIPTION
The `lwt` install "messages" recommend explicitly depending on `lwt_log` and `lwt_camlp4`.

The proposed `CHANGES.md` updates come from `git log --pretty=oneline 1.1.7..master`